### PR TITLE
revise pip3 install  lslautobids code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ git clone https://github.com/s-ccs/LSLAutoBIDS.git
 Go to the cloned directory and install the package using pip.
 ```
 cd LSLAutoBIDS
-pip3 install lslautobids
+pip3 install .
 ```
 It is advised to install the package in a separate environment (e.g. using `conda` or `virtualenv`).
 


### PR DESCRIPTION
I find 'pip3 install lslautobids" can not work. The logic of pip is to search in the Internet first if we use specific package name. But if we use "pip3 install .", it will search for 'setup.py' first and then download the depandancy.